### PR TITLE
Zip response and general cleanup

### DIFF
--- a/src/api/console.go
+++ b/src/api/console.go
@@ -82,23 +82,21 @@ func Console() {
 	fmt.Println(string(output))
 
 	date := time.Date(yearParsed, time.January, 1, 0, 0, 0, 0, time.UTC)
+	os.Chdir(repoName)
+
 	if design == "checkered" {
-		os.Chdir(repoName)
 		designs.DrawCheckered(date, yearParsed)
 	}
 	if design == "give" {
 		date = helpers.FindFirstSunday(date)
-		os.Chdir(repoName)
 		designs.DrawGive(date)
 	}
 	if design == "table flip" {
 		date = helpers.FindFirstSunday(date)
-		os.Chdir(repoName)
 		designs.DrawTableFlip(date)
 	}
 	if design == "word" {
 		date = helpers.FindFirstSunday(date)
-		os.Chdir(repoName)
 		designs.DrawWord(word, date)
 	}
 	if design == "matrix" {
@@ -112,7 +110,6 @@ func Console() {
 			fmt.Printf("Error whilde decoding %v\n", err)
 			log.Fatal(err)
 		}
-		os.Chdir(repoName)
 		designs.DrawMatixPatern(date, matrixRequest.Matrix)
 	}
 }

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"git-art/src/designs"
 	"git-art/src/helpers"
 	"log"
@@ -90,4 +91,6 @@ func MakeArt(context *gin.Context) {
 		designs.DrawWord(json.Word, date)
 	}
 	os.Chdir("..")
+
+	helpers.Zipit(json.RepoName, fmt.Sprintf("%v.zip", json.RepoName))
 }

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -95,4 +95,7 @@ func MakeArt(context *gin.Context) {
 	helpers.Zipit(json.RepoName, fmt.Sprintf("%v.zip", json.RepoName))
 
 	context.FileAttachment(fmt.Sprintf("%v.zip", json.RepoName), "file")
+
+	os.RemoveAll(json.RepoName)
+	os.Remove(fmt.Sprintf("%v.zip", json.RepoName))
 }

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -93,4 +93,6 @@ func MakeArt(context *gin.Context) {
 	os.Chdir("..")
 
 	helpers.Zipit(json.RepoName, fmt.Sprintf("%v.zip", json.RepoName))
+
+	context.FileAttachment(fmt.Sprintf("%v.zip", json.RepoName), "file")
 }

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -92,10 +92,11 @@ func MakeArt(context *gin.Context) {
 	}
 	os.Chdir("..")
 
-	helpers.Zipit(json.RepoName, fmt.Sprintf("%v.zip", json.RepoName))
+	zipFile := fmt.Sprintf("%v.zip", json.RepoName)
+	helpers.Zipit(json.RepoName, zipFile)
 
-	context.FileAttachment(fmt.Sprintf("%v.zip", json.RepoName), "file")
+	context.FileAttachment(zipFile, "file")
 
 	os.RemoveAll(json.RepoName)
-	os.Remove(fmt.Sprintf("%v.zip", json.RepoName))
+	os.Remove(zipFile)
 }

--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -1,9 +1,13 @@
 package helpers
 
 import (
+	"archive/zip"
+	"io"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -32,4 +36,65 @@ func FindFirstSunday(date time.Time) time.Time {
 // AddDays is a helper function to make the copy pasta simpler
 func AddDays(date time.Time, days int) time.Time {
 	return date.Add(time.Hour * 24 * time.Duration(days))
+}
+
+func Zipit(source, target string) error {
+	zipfile, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer zipfile.Close()
+
+	archive := zip.NewWriter(zipfile)
+	defer archive.Close()
+
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil
+	}
+
+	var baseDir string
+	if info.IsDir() {
+		baseDir = filepath.Base(source)
+	}
+
+	filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		if baseDir != "" {
+			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+		}
+
+		if info.IsDir() {
+			header.Name += "/"
+		} else {
+			header.Method = zip.Deflate
+		}
+
+		writer, err := archive.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.Copy(writer, file)
+		return err
+	})
+
+	return err
 }

--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -38,6 +38,7 @@ func AddDays(date time.Time, days int) time.Time {
 	return date.Add(time.Hour * 24 * time.Duration(days))
 }
 
+// Zipit zips up a directory into a zip file
 func Zipit(source, target string) error {
 	zipfile, err := os.Create(target)
 	if err != nil {


### PR DESCRIPTION
## Description
Makes the REST endpoint return a zip file of the repository.  The `Zipit` method was taken from the internet and might be worth looking into if there is a better way to do it or if there is any cleanup that should be done.
Also some small cleanup with os navigation for console entry point